### PR TITLE
Fix: Set location accuracy

### DIFF
--- a/lib/logic/geolocation/bloc/location_bloc.dart
+++ b/lib/logic/geolocation/bloc/location_bloc.dart
@@ -14,8 +14,7 @@ class LocationBloc extends Bloc<LocationEvent, LocationState> {
     on<LocationStarted>(_onStarted);
     on<LocationUpdated>(_onLocationUpdated);
     _locationSubscription = Geolocator.getPositionStream(
-            locationSettings:
-                const LocationSettings(accuracy: LocationAccuracy.medium))
+            locationSettings: const LocationSettings(distanceFilter: 20))
         .listen(
       (position) => add(LocationUpdated(position)),
     );


### PR DESCRIPTION
### Description

Location request was being called multiple times per second. This performance isn't the best we can get.

This PR sets the `distanceFilter` parameter to 20 meters.

Closes #43 

### Demo

Performance before change:

![image](https://github.com/ISIS3510-202320-Team13/Flutter/assets/69475004/cce24b1f-7a75-4519-a121-d258a018e516)

Performance after change:

![image](https://github.com/ISIS3510-202320-Team13/Flutter/assets/69475004/b1e23f14-694f-4133-9202-43fe96aace2f)
